### PR TITLE
_join_timeout didn't have self as first argument

### DIFF
--- a/occamy/channel.py
+++ b/occamy/channel.py
@@ -107,7 +107,7 @@ class Channel:
                 push_event.send()
             self._push_buffer = []
 
-    def _join_timeout():
+    def _join_timeout(self):
         with self._lock:
             if self._state != Channel.STATES['joining']:
                 return


### PR DESCRIPTION
It didn't crash before. This also means that the function was never called.
TODO look into it!
