### PR TITLE
State typo

### DIFF
--- a/occamy/channel.py
+++ b/occamy/channel.py
@@ -109,7 +109,7 @@ class Channel:
 
     def _join_timeout():
         with self._lock:
-            if self._state != Channel.STATES['joining']:
+            if not self._is_joining():
                 return
             self._logger.debug("channel timeout ({timeout}) on topic {topic}".format(timeout=self._join_push.timeout(), topic=self._topic))
             self._state = Channel.STATES['errored']
@@ -128,7 +128,7 @@ class Channel:
             self._rejoin_timer.start()
 
     def _can_push(self):
-        return self._socket.is_connected() and self._state == Channel.STATES['joined']
+        return self._socket.is_connected() and self._is_joined()
 
     def _on_message(self, event, payload, ref):
         pass
@@ -146,4 +146,18 @@ class Channel:
         
     def reply_event_name(self, ref):
         return "chan_reply_{ref}".format(ref=ref)
-        
+
+    def _is_closed(self):
+        return self._state == Channel.STATES["closed"]
+
+    def _is_errored(self):
+        return self._state == Channel.STATES["errored"]
+
+    def _is_joined(self):
+        return self._state == Channel.STATES["joined"]
+
+    def _is_joining(self):
+        return self._state == Channel.STATES["joining"]
+
+    def _is_leaving(self):
+        return self._state == Channel.STATES["leaving"]

--- a/occamy/channel.py
+++ b/occamy/channel.py
@@ -6,7 +6,7 @@ class Channel:
     STATES = dict(closed = "closed",
                   errored = "errored",
                   joined = "joined",
-                  joining = "joinging")
+                  joining = "joining")
     EVENTS = dict(close = 'phx_close',
                   error = 'phx_error',
                   join = 'phx_join',


### PR DESCRIPTION
`joinging` -> `joining`

I also introduced helper function (similar to the js implementation) to avoid these kind of typos.

We could also use enums instead of the dict.

Or a simple class (to prevent the enum34 dependency for python2):

```
class STATES:
    closed = "closed"
    errored = "errored"
    joined = "joined"
    joining = "joining"
```
