### PR TITLE
Use list comprehensions instead of filters (py3 comp.)

### DIFF
--- a/occamy/channel.py
+++ b/occamy/channel.py
@@ -55,7 +55,7 @@ class Channel:
         self._bindings.append(dict(event=event, callback=cb))
 
     def off(self, event):
-        self._bindings = filter(lambda binding: binding['event'] != event, self._bindings)
+        self._bindings = [b for b in self._bindings if b['event'] != event]
 
     def is_member(self, topic):
         return self._topic == topic
@@ -140,7 +140,7 @@ class Channel:
 
     def trigger(self, event, payload=None, ref=None):
         self._on_message(event, payload, ref)
-        bindings = filter(lambda binding: binding['event'] == event, self._bindings)
+        bindings = [b for b in self._bindings if b['event'] == event]
         for binding in bindings:
             binding['callback'](payload, ref)
         

--- a/occamy/push.py
+++ b/occamy/push.py
@@ -76,7 +76,7 @@ class Push:
             self._timer.cancel()
             self._timer = None
             self._received_resp = payload
-            hooks = filter(lambda hook: hook['status'] == status, self._recv_hooks)
+            hooks = [h for h in self._recv_hook if h['status'] == status]
 
         for hook in map(lambda hook: hook['callback'], hooks):
             hook(response)

--- a/occamy/socket.py
+++ b/occamy/socket.py
@@ -32,7 +32,7 @@ class WebSocketImpl(WebSocketClient):
 
     def remove_observer(self, observer):
         with self._lock:
-            self._observers = filter(lambda o: o != observer, self._observers)
+            self._observers = [o for o in self._observers if o != observer]
 
     def remove_observers(self):
         observers = []
@@ -125,7 +125,7 @@ class Socket(WebSocketObserver):
 
         channels = []
         with self._lock:
-            channels = filter(lambda ch: ch.is_member(topic), self._channels)
+            channels = [ch for ch in self._channels if ch.is_member(topic)]
 
         for channel in channels:
             channel.trigger(event, payload, ref)
@@ -144,19 +144,20 @@ class Socket(WebSocketObserver):
 
     def timeout(self):
         return self._timeout
-    
+
     def is_connected(self):
         return self._opened == True
 
     def connect(self):
         self._websocket_impl.connect()
-    
+
     def disconnect(self, callback=None, code=1000, reason=''):
         self._websocket_impl.close(code, reason)
 
     def remove(self, channel):
         with self._lock:
-            self._channels = filter(lambda ch: not ch.is_member(channel.topic), self._channels)
+            self._channels = [ch for ch in self._channels
+                              if not ch.is_member(channel.topic)]
 
     def channel(self, topic, params):
         channel = Channel(topic, params, self)


### PR DESCRIPTION
filter in py3 returns a filter object, not a list.
Using list comprehensions works with py2 & py3, and it's easy to read.
