### PR TITLE
Socket can be imported from occamy directly

### DIFF
--- a/occamy/__init__.py
+++ b/occamy/__init__.py
@@ -1,1 +1,3 @@
+from .socket import Socket
 
+__all__ = ["Socket"]


### PR DESCRIPTION
No need for `from occamy.socket import Socket` anymore,
now you can directly `from occamy import Socket`.
